### PR TITLE
Avoid "mod" files from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@
 *.o.cmd
 .tmp_versions
 *.symvers
-*.mod.c
-*.mod.o
+*.mod*
 *.order
 *.o
 *.ko


### PR DESCRIPTION
After compiling, there are two compiling results
had been generated:
    `.khttpd.mod.cmd`
    `khttpd.mod`

which had not been listed in `.gitignore` file.

I revise `.gitignore` to prevent `*.mod*` from
listing while tracking files.