### PR TITLE
Perform static analysis over git-tracked files only

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -4,7 +4,7 @@ CPPCHECK_suppresses="--suppress=missingIncludeSystem \
 	             --suppress=unusedFunction:http_parser.c \
                      --suppress=duplicateBreak:http_parser.c \
                      --suppress=shadowVariable:http_parser.c"
-CPPCHECK_OPTS="-I. --enable=all --error-exitcode=1 --force $CPPCHECK_suppresses ."
+CPPCHECK_OPTS="-I. --enable=all --error-exitcode=1 --force $CPPCHECK_suppresses"
 
 RETURN=0
 CLANG_FORMAT=$(which clang-format)
@@ -76,7 +76,9 @@ do
 done
 
 # static analysis
-$CPPCHECK $CPPCHECK_OPTS >/dev/null
+git ls-tree --full-tree -r --name-only HEAD | \
+   grep -v compat | grep -E "\.(c|cc|cpp|h|hh|hpp)\$" | \
+   xargs $CPPCHECK $CPPCHECK_OPTS >/dev/null
 if [ $? -ne 0 ]; then
     RETURN=1
     echo "" >&2


### PR DESCRIPTION
Cppcheck might fail when trying to check `http_parser.c`

Since `http_parser.c` is been ignored from adding into
commit, we don't have to check it in pre-commit stage.

I add CPPCHECK_ignore into `scripts/pre-commit.hook`
to prevent Cppcheck from checking it.