### PR TITLE
Replace __sync with C11 Atomics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 KDIR=/lib/modules/$(shell uname -r)/build
 
-CFLAGS_user = -std=gnu99 -Wall -Wextra -Werror
+CFLAGS_user = -std=gnu11 -Wall -Wextra -Werror
 LDFLAGS_user = -lpthread
 
 obj-m += khttpd.o


### PR DESCRIPTION
Since __sync* functions had been marked as legacy functions in [GCC Extensions](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fsync-Builtins.html), I replace them with atomic* functions defined in [<stdatomic.h>](https://en.cppreference.com/w/c/atomic)