### PR TITLE
Fix invalid memory access during parsing URI

### DIFF
--- a/htstress.c
+++ b/htstress.c
@@ -151,8 +151,7 @@ static void init_conn(int efd, struct econn *ec)
     }
 
     struct epoll_event evt = {
-        .events = EPOLLOUT,
-        .data.ptr = ec,
+        .events = EPOLLOUT, .data.ptr = ec,
     };
 
     if (epoll_ctl(efd, EPOLL_CTL_ADD, ec->fd, &evt)) {
@@ -429,14 +428,16 @@ int main(int argc, char *argv[])
         *rq++ = 0;
         port = rq;
         rq = strchr(rq, '/');
-        if (*rq == '/') {
-            port = strndup(port, rq - port);
-            if (!port) {
-                perror("port = strndup(rq, rq - port)");
-                exit(EXIT_FAILURE);
-            }
-        } else
-            rq = "/";
+        if (rq) {
+            if (*rq == '/') {
+                port = strndup(port, rq - port);
+                if (!port) {
+                    perror("port = strndup(rq, rq - port)");
+                    exit(EXIT_FAILURE);
+                }
+            } else
+                rq = "/";
+        }
     }
 
     if (strnlen(udaddr, sizeof(ssun->sun_path) - 1) == 0) {

--- a/htstress.c
+++ b/htstress.c
@@ -487,9 +487,12 @@ int main(int argc, char *argv[])
     /* prepare request buffer */
     if (!host)
         host = node;
-    outbufsize = strlen(rq) + sizeof(HTTP_REQUEST_FMT) + strlen(host);
+    outbufsize = sizeof(HTTP_REQUEST_FMT) + strlen(host);
+    outbufsize += rq ? strlen(rq) : 1;
+
     outbuf = malloc(outbufsize);
-    outbufsize = snprintf(outbuf, outbufsize, HTTP_REQUEST_FMT, rq, host);
+    outbufsize = rq ? snprintf(outbuf, outbufsize, HTTP_REQUEST_FMT, rq, host)
+                    : snprintf(outbuf, outbufsize, HTTP_REQUEST_FMT, "/", host);
 
     ticks = max_requests / 10;
 

--- a/htstress.c
+++ b/htstress.c
@@ -491,8 +491,8 @@ int main(int argc, char *argv[])
     outbufsize += rq ? strlen(rq) : 1;
 
     outbuf = malloc(outbufsize);
-    outbufsize = rq ? snprintf(outbuf, outbufsize, HTTP_REQUEST_FMT, rq, host)
-                    : snprintf(outbuf, outbufsize, HTTP_REQUEST_FMT, "/", host);
+    outbufsize =
+        snprintf(outbuf, outbufsize, HTTP_REQUEST_FMT, rq ? rq : "/", host);
 
     ticks = max_requests / 10;
 


### PR DESCRIPTION
I have found that input URI "http://127.0.0.1:8081" to "htstress" makes a segmentation fault. After checking the source code, the string processing for parsing port number makes a NULL pointer access. In addition, I also found that NULL pointer input to strlen() function also makes a segmentation fault. This two memory bug is fixed in this pull request. 

Furthermore, path for accessed resource in URI "http://127.0.0.1:8081" is not assigned (path for accessed resource is NULL). Referring to FireFox web browser`s implementation, FireFox automatically replace NULL path to "/". The function is also implemented in this pull request. 

For detail process of checking error, please visit https://hackmd.io/@StevenHHChen/sehttpd_linux2020