### PR TITLE
Replace set socket option function

### DIFF
--- a/main.c
+++ b/main.c
@@ -21,11 +21,11 @@ static struct http_server_param param;
 static struct task_struct *http_server;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
-static int _sock_setsockopt(struct socket *sock,
-                            int level,
-                            int optname,
-                            char *optval,
-                            unsigned int optlen)
+static int set_sock_opt(struct socket *sock,
+                        int level,
+                        int optname,
+                        char *optval,
+                        unsigned int optlen)
 {
     int ret = 0;
 
@@ -44,11 +44,11 @@ static int _sock_setsockopt(struct socket *sock,
     return ret;
 }
 
-static int _tcp_setsockopt(struct socket *sock,
-                           int level,
-                           int optname,
-                           char *optval,
-                           unsigned int optlen)
+static int set_tcp_opt(struct socket *sock,
+                       int level,
+                       int optname,
+                       char *optval,
+                       unsigned int optlen)
 {
     int ret = 0;
 
@@ -74,9 +74,9 @@ static int kernel_setsockopt(struct socket *sock,
                              unsigned int optlen)
 {
     if (level == SOL_SOCKET)
-        return _sock_setsockopt(sock, level, optname, optval, optlen);
+        return set_sock_opt(sock, level, optname, optval, optlen);
     else if (level == SOL_TCP)
-        return _tcp_setsockopt(sock, level, optname, optval, optlen);
+        return set_tcp_opt(sock, level, optname, optval, optlen);
     else
         return -EINVAL;
 }

--- a/main.c
+++ b/main.c
@@ -77,8 +77,7 @@ static int kernel_setsockopt(struct socket *sock,
         return set_sock_opt(sock, level, optname, optval, optlen);
     else if (level == SOL_TCP)
         return set_tcp_opt(sock, level, optname, optval, optlen);
-    else
-        return -EINVAL;
+    return -EINVAL;
 }
 #endif
 

--- a/main.c
+++ b/main.c
@@ -3,6 +3,7 @@
 #include <linux/kthread.h>
 #include <linux/sched/signal.h>
 #include <linux/tcp.h>
+#include <linux/version.h>
 #include <net/sock.h>
 
 #include "http_server.h"
@@ -19,6 +20,51 @@ static struct socket *listen_socket;
 static struct http_server_param param;
 static struct task_struct *http_server;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 8, 0)
+static inline int setsockopt(struct socket *sock,
+                             int level,
+                             int optname,
+                             int optval)
+{
+    int opt = optval;
+    return kernel_setsockopt(sock, level, optname, (char *) &opt, sizeof(opt));
+}
+
+static int set_sockopt(struct socket *sock)
+{
+    int err = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, 1);
+    if (err < 0)
+        return err;
+
+    err = setsockopt(sock, SOL_TCP, TCP_NODELAY, 1);
+    if (err < 0)
+        return err;
+
+    err = setsockopt(sock, SOL_TCP, TCP_CORK, 0);
+    if (err < 0)
+        return err;
+
+    err = setsockopt(sock, SOL_SOCKET, SO_RCVBUF, 1024 * 1024);
+    if (err < 0)
+        return err;
+
+    err = setsockopt(sock, SOL_SOCKET, SO_SNDBUF, 1024 * 1024);
+    return err;
+}
+
+#else /* KERNEL_VERSION >= 5.8.0 */
+
+static int set_sockopt(struct socket *sock)
+{
+    sock_set_reuseaddr(sock->sk);
+    tcp_sock_set_nodelay(sock->sk);
+    tcp_sock_set_cork(sock->sk, 0);
+    sock_set_rcvbuf(sock->sk, 1024 * 1024);
+    return 0;
+}
+
+#endif
+
 static int open_listen_socket(ushort port, ushort backlog, struct socket **res)
 {
     struct socket *sock;
@@ -30,10 +76,9 @@ static int open_listen_socket(ushort port, ushort backlog, struct socket **res)
         return err;
     }
 
-    sock_set_reuseaddr(sock->sk);
-    tcp_sock_set_nodelay(sock->sk);
-    tcp_sock_set_cork(sock->sk, 0);
-    sock_set_rcvbuf(sock->sk, 1024 * 1024);
+    err = set_sockopt(sock);
+    if (err < 0)
+        goto bail_setsockopt;
 
     memset(&s, 0, sizeof(s));
     s.sin_family = AF_INET;
@@ -53,6 +98,8 @@ static int open_listen_socket(ushort port, ushort backlog, struct socket **res)
     *res = sock;
     return 0;
 
+bail_setsockopt:
+    pr_err("set_sockopt() failure, err=%d\n", err);
 bail_sock:
     sock_release(sock);
     return err;


### PR DESCRIPTION
kernel_setsockopt was removed since Linux v5.8 which is the Ubuntu 
20.04.2 LTS default version.
Note that in Linux v5.8, sock_setsockopt only accept user space val as
argument. There is no good method to set sndbuf without changing kernel
source.