### PR TITLE
Shutdown socket before release

### DIFF
--- a/http_server.c
+++ b/http_server.c
@@ -217,6 +217,7 @@ int http_server_daemon(void *arg)
         worker = kthread_run(http_server_worker, socket, KBUILD_MODNAME);
         if (IS_ERR(worker)) {
             pr_err("can't create more worker process\n");
+            kernel_sock_shutdown(socket, SHUT_RDWR);
             sock_release(socket);
             continue;
         }


### PR DESCRIPTION
Calling sock_release() directly when worker thread creation fails may leave the socket not properly
shut down, potentially causing incomplete resource cleanup. This change adds a call to kernel_sock_shutdown() before releasing the socket, ensuring the connection is properly closed and reducing the risk of resource leaks or abnormal network states.