### PR TITLE
Introduce CMWQ for request handling

### DIFF
--- a/http_server.c
+++ b/http_server.c
@@ -32,11 +32,16 @@
 
 #define RECV_BUFFER_SIZE 4096
 
+extern struct workqueue_struct *khttpd_wq;
+struct httpd_service daemon_list = {.is_stopped = false};
+
 struct http_request {
     struct socket *socket;
     enum http_method method;
     char request_url[128];
     int complete;
+    struct list_head node;
+    struct work_struct khttpd_work;
 };
 
 static int http_server_recv(struct socket *sock, char *buf, size_t size)
@@ -145,8 +150,10 @@ static int http_parser_callback_message_complete(http_parser *parser)
     return 0;
 }
 
-static int http_server_worker(void *arg)
+static void http_server_worker(struct work_struct *work)
 {
+    struct http_request *worker =
+        container_of(work, struct http_request, khttpd_work);
     char *buf;
     struct http_parser parser;
     struct http_parser_settings setting = {
@@ -158,9 +165,6 @@ static int http_server_worker(void *arg)
         .on_body = http_parser_callback_body,
         .on_message_complete = http_parser_callback_message_complete,
     };
-    struct http_request request;
-    struct socket *socket = (struct socket *) arg;
-    int err = 0;
 
     allow_signal(SIGKILL);
     allow_signal(SIGTERM);
@@ -168,43 +172,63 @@ static int http_server_worker(void *arg)
     buf = kzalloc(RECV_BUFFER_SIZE, GFP_KERNEL);
     if (!buf) {
         pr_err("can't allocate memory!\n");
-        err = -ENOMEM;
-        goto out;
+        return;
     }
 
-    request.socket = socket;
     http_parser_init(&parser, HTTP_REQUEST);
-    parser.data = &request;
-    while (!kthread_should_stop()) {
-        int ret = http_server_recv(socket, buf, RECV_BUFFER_SIZE - 1);
+    parser.data = worker;
+    while (!daemon_list.is_stopped) {
+        int ret = http_server_recv(worker->socket, buf, RECV_BUFFER_SIZE - 1);
         if (ret <= 0) {
-            if (ret) {
+            if (ret)
                 pr_err("recv error: %d\n", ret);
-                err = ret;
-            }
-            goto out_free_buf;
+            break;
         }
         http_parser_execute(&parser, &setting, buf, ret);
-        if (request.complete && !http_should_keep_alive(&parser))
-            goto out_free_buf;
+        if (worker->complete && !http_should_keep_alive(&parser))
+            break;
         memset(buf, 0, RECV_BUFFER_SIZE);
     }
-out_free_buf:
+    kernel_sock_shutdown(worker->socket, SHUT_RDWR);
+    sock_release(worker->socket);
     kfree(buf);
-out:
-    kernel_sock_shutdown(socket, SHUT_RDWR);
-    sock_release(socket);
-    return err;
+    return;
+}
+
+static struct work_struct *create_work(struct socket *sk)
+{
+    struct http_request *work = kmalloc(sizeof(*work), GFP_KERNEL);
+    if (!work)
+        return NULL;
+
+    work->socket = sk;
+    INIT_WORK(&work->khttpd_work, http_server_worker);
+    list_add(&work->node, &daemon_list.head);
+    return &work->khttpd_work;
+}
+
+static void free_work(void)
+{
+    struct http_request *tar, *tmp;
+
+    list_for_each_entry_safe (tar, tmp, &daemon_list.head, node) {
+        kernel_sock_shutdown(tar->socket, SHUT_RDWR);
+        flush_work(&tar->khttpd_work);
+        sock_release(tar->socket);
+        kfree(tar);
+    }
 }
 
 int http_server_daemon(void *arg)
 {
     struct socket *socket;
-    struct task_struct *worker;
+    struct work_struct *work;
     struct http_server_param *param = (struct http_server_param *) arg;
 
     allow_signal(SIGKILL);
     allow_signal(SIGTERM);
+
+    INIT_LIST_HEAD(&daemon_list.head);
 
     while (!kthread_should_stop()) {
         int err = kernel_accept(param->listen_socket, &socket, 0);
@@ -214,13 +238,19 @@ int http_server_daemon(void *arg)
             pr_err("kernel_accept() error: %d\n", err);
             continue;
         }
-        worker = kthread_run(http_server_worker, socket, KBUILD_MODNAME);
-        if (IS_ERR(worker)) {
+
+        if (unlikely(!(work = create_work(socket)))) {
             pr_err("can't create more worker process\n");
             kernel_sock_shutdown(socket, SHUT_RDWR);
             sock_release(socket);
             continue;
         }
+
+        queue_work(khttpd_wq, work);
     }
+
+    daemon_list.is_stopped = true;
+    free_work();
+
     return 0;
 }

--- a/http_server.h
+++ b/http_server.h
@@ -1,10 +1,19 @@
 #ifndef KHTTPD_HTTP_SERVER_H
 #define KHTTPD_HTTP_SERVER_H
 
+#include <linux/list.h>
+#include <linux/workqueue.h>
 #include <net/sock.h>
+
+#define MODULE_NAME "khttpd"
 
 struct http_server_param {
     struct socket *listen_socket;
+};
+
+struct httpd_service {
+    bool is_stopped;       /* 是否收到終止訊號 */
+    struct list_head head; /* 串列首節點 */
 };
 
 extern int http_server_daemon(void *arg);


### PR DESCRIPTION
Replace the default system workqueue with Concurrency Managed Work Queue (CMWQ) to enhance performance and throughput. The system workqueue is shared across the entire kernel and can become a bottleneck under heavy load, while a dedicated CMWQ provides better isolation and scalability.

Use the following command to measure the throughput.:
```bash
./htstress http://localhost:8081 -t 3 -c 20 -n 200000
```
The parameters of this command are as follows:
- `-t 3`: Use 3 threads
- `-c 20`: Maintain 20 concurrent connections
- `-n 200000`: Send a total of 200,000 requests
- `http://localhost:8081`：The URL where the server is hosted

Test result:
```bash
requests:      200000
good requests: 200000 [100%]
bad requests:  0 [0%]
socket errors: 0 [0%]
seconds:       12.917
requests/sec:  15483.061
```
```bash
requests:      200000
good requests: 200000 [100%]
bad requests:  0 [0%]
socket errors: 0 [0%]
seconds:       6.489
requests/sec:  30823.589
```
| Original | CMWQ |
| ---------- | --------- |
| 15483.061  | 30823.589 |

After implementing CMWQ, the throughput achieved approximately 50% improvement compared to the original implementation.