### PR TITLE
Replace kzalloc with mempool to reduce memory fragmentation

### DIFF
--- a/http_server.c
+++ b/http_server.c
@@ -30,7 +30,6 @@
     "Content-Type: text/plain" CRLF "Content-Length: 21" CRLF          \
     "Connection: KeepAlive" CRLF CRLF "501 Not Implemented" CRLF
 
-#define RECV_BUFFER_SIZE 4096
 
 struct http_request {
     struct socket *socket;
@@ -165,7 +164,7 @@ static int http_server_worker(void *arg)
     allow_signal(SIGKILL);
     allow_signal(SIGTERM);
 
-    buf = kzalloc(RECV_BUFFER_SIZE, GFP_KERNEL);
+    buf = mempool_alloc(http_buf_pool, GFP_KERNEL);
     if (!buf) {
         pr_err("can't allocate memory!\n");
         err = -ENOMEM;
@@ -190,7 +189,7 @@ static int http_server_worker(void *arg)
         memset(buf, 0, RECV_BUFFER_SIZE);
     }
 out_free_buf:
-    kfree(buf);
+    mempool_free(buf, http_buf_pool);
 out:
     kernel_sock_shutdown(socket, SHUT_RDWR);
     sock_release(socket);

--- a/http_server.h
+++ b/http_server.h
@@ -3,10 +3,22 @@
 
 #include <net/sock.h>
 
+#define RECV_BUFFER_SIZE 4096
+extern mempool_t *http_buf_pool;
+
 struct http_server_param {
     struct socket *listen_socket;
 };
 
 extern int http_server_daemon(void *arg);
 
+static inline void *http_buf_alloc(gfp_t gfp_mask, void *pool_data)
+{
+    return kzalloc(RECV_BUFFER_SIZE, gfp_mask);
+}
+
+static inline void http_buf_free(void *element, void *pool_data)
+{
+    kfree(element);
+}
 #endif


### PR DESCRIPTION
Replace kzalloc with mempool to reduce memory fragmentation

Using mempool improves memory allocation stability and reduces fragmentation
in high-frequency allocation scenarios, especially under memory pressure.